### PR TITLE
Fix converter for empty block

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -231,8 +231,9 @@ class Converter
     protected function renderBlockContent(ContentBlock $block, DOMElement $element): DOMElement
     {
         if ('' === $block->text) {
-            // Prevent element collapse if completely empty.
-            return self::BREAK_LINE;
+            $element->appendChild($this->doc->createElement('br'));
+
+            return $element;
         }
 
         $entityRanges = $this->getEntityRanges($this->preserveWhitespace($block->text), $block->characterList);


### PR DESCRIPTION
Error: Type error: Return value of Willtj\PhpDraftjsHtml\Converter::renderBlockContent() must be an instance of DOMElement, string returned

In case of an empty text we have to return a DOMElement and not a string.

Zube: https://zube.io/20minutes/vega/c/13944
Github Issue: https://github.com/20minutes/vega/issues/9163