### PR TITLE
Handle UTF8 chars during conversion to html

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -314,7 +314,7 @@ class Converter
         $ranges = [];
         $rangeStart = 0;
 
-        foreach (str_split($text) as $i => $char) {
+        foreach (mb_str_split($text, 1, 'UTF-8') as $i => $char) {
             $prevCharEntity = $charEntity;
 
             $meta = $characterMetaList[$i] ?? null;
@@ -324,7 +324,7 @@ class Converter
                 $ranges[] = [
                     'key' => $prevCharEntity,
                     'styleRanges' => $this->getStyleRanges(
-                        substr($text, $rangeStart, $i - $rangeStart),
+                        mb_substr($text, $rangeStart, $i - $rangeStart),
                         \array_slice($characterMetaList, $rangeStart, $i - $rangeStart)
                     ),
                 ];
@@ -335,7 +335,7 @@ class Converter
 
         $ranges[] = [
             'key' => $charEntity,
-            'styleRanges' => $this->getStyleRanges(substr($text, $rangeStart), \array_slice($characterMetaList, $rangeStart)),
+            'styleRanges' => $this->getStyleRanges(mb_substr($text, $rangeStart), \array_slice($characterMetaList, $rangeStart)),
         ];
 
         return $ranges;
@@ -348,14 +348,13 @@ class Converter
         $ranges = [];
         $rangeStart = 0;
 
-        foreach (str_split($text) as $i => $char) {
+        foreach (mb_str_split($text, 1, 'UTF-8') as $i => $char) {
             $prevCharStyle = $charStyle;
             $meta = $charMetaList[$i] ?? null;
             $charStyle = $meta ? $meta->style : [];
-
             if ($i > 0 && $charStyle !== $prevCharStyle) {
                 $ranges[] = [
-                    'text' => substr($text, $rangeStart, $i - $rangeStart),
+                    'text' => mb_substr($text, $rangeStart, $i - $rangeStart, 'UTF-8'),
                     'styles' => $prevCharStyle,
                 ];
 
@@ -364,7 +363,7 @@ class Converter
         }
 
         $ranges[] = [
-            'text' => substr($text, $rangeStart),
+            'text' => mb_substr($text, $rangeStart, null, 'UTF-8'),
             'styles' => $charStyle,
         ];
 

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -120,6 +120,11 @@ class ConverterTest extends TestCase
                 '{"entityMap":{},"blocks":[{"data": {}, "key":"33nh8","text":"An ordered list:","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"data":{},"key":"8kinl","text":"One","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"data":{},"key":"ekll4","text":"Two","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}',
                 '<p>An ordered list:</p><ol><li>One</li><li>Two</li></ol>',
             ],
+            // Style with accents
+            [
+                '{"entityMap":{},"blocks":[{"depth":0,"data":{},"inlineStyleRanges":[{"offset":23,"length":5,"style":"BOLD"}],"text":"Testé avec dès accents Texte 1","type":"unstyled","key":"9lnff","entityRanges":[]}]}',
+                '<p>Testé avec dès accents <strong>Texte</strong> 1</p>',
+            ],
         ];
     }
 


### PR DESCRIPTION
I changed some functions to handle multiple bytes UTF-8 chars (`str_split` & `substr`).

![image](https://user-images.githubusercontent.com/18148265/97714460-7b070500-1ac1-11eb-8717-11de9194fd0e.png)
Expected

![image](https://user-images.githubusercontent.com/18148265/97714392-6460ae00-1ac1-11eb-857d-23ff6b867973.png)
Response test on API Gateway